### PR TITLE
#103 - added tooltips

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -3,3 +3,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.tooltip {
+    @apply invisible absolute;
+}
+
+.has-tooltip:hover .tooltip {
+    @apply visible z-50;
+}

--- a/resources/js/Pages/Dashboard/ContactInfo/Index.vue
+++ b/resources/js/Pages/Dashboard/ContactInfo/Index.vue
@@ -9,7 +9,7 @@ import Button from '@/Shared/Components/Buttons/Button.vue'
 import EmptyState from '@/Shared/Components/EmptyState.vue'
 import RemoveModal from '@/Shared/Modals/RemoveModal.vue'
 import { ref } from 'vue'
-import { Cog6ToothIcon, XCircleIcon } from '@heroicons/vue/24/outline'
+import { PencilSquareIcon, XCircleIcon } from '@heroicons/vue/24/outline'
 import ManagementHeader from '@/Shared/Components/ManagementHeader.vue'
 import ManagementHeaderItem from '@/Shared/Components/ManagementHeaderItem.vue'
 defineProps({
@@ -73,7 +73,7 @@ const contactInfoToDeleteId = ref(0)
               </TableCell>
               <TableCell class="flex justify-end gap-2">
                 <Button :href="`contact-infos/${contact.id}/edit`">
-                  <Cog6ToothIcon class="w-5" />
+                  <PencilSquareIcon class="w-5" />
                 </Button>
                 <Button class="text-red-600" @click="[showModal = true, contactInfoToDeleteId = contact.id]">
                   <XCircleIcon class="w-5" />

--- a/resources/js/Pages/Dashboard/Course/Index.vue
+++ b/resources/js/Pages/Dashboard/Course/Index.vue
@@ -10,7 +10,7 @@ import RemoveModal from '@/Shared/Modals/RemoveModal.vue'
 import { ref } from 'vue'
 import ManagementHeader from '@/Shared/Components/ManagementHeader.vue'
 import ManagementHeaderItem from '@/Shared/Components/ManagementHeaderItem.vue'
-import { Cog6ToothIcon, XCircleIcon } from '@heroicons/vue/24/outline'
+import { PencilSquareIcon, XCircleIcon } from '@heroicons/vue/24/outline'
 
 defineProps({
   courses: Object,
@@ -83,7 +83,7 @@ const courseToDeleteId = ref(0)
               </TableCell>
               <TableCell class="flex justify-end gap-2">
                 <Button :href="`/dashboard/courses/${course.id}/edit`">
-                  <Cog6ToothIcon class="w-5" />
+                  <PencilSquareIcon class="w-5" />
                 </Button>
                 <Button class="text-red-600" @click="[showModal = true, courseToDeleteId = course.id]">
                   <XCircleIcon class="w-5" />

--- a/resources/js/Pages/Dashboard/CourseSemester/Index.vue
+++ b/resources/js/Pages/Dashboard/CourseSemester/Index.vue
@@ -10,7 +10,7 @@ import RemoveModal from '@/Shared/Modals/RemoveModal.vue'
 import { ref } from 'vue'
 import ManagementHeader from '@/Shared/Components/ManagementHeader.vue'
 import ManagementHeaderItem from '@/Shared/Components/ManagementHeaderItem.vue'
-import { Cog6ToothIcon, XCircleIcon, EyeIcon } from '@heroicons/vue/24/outline'
+import { PencilSquareIcon, XCircleIcon, EyeIcon } from '@heroicons/vue/24/outline'
 
 defineProps({
   courses: Object,
@@ -88,7 +88,7 @@ const courseToDeleteId = ref(0)
                   <EyeIcon class="w-5" />
                 </Button>
                 <Button :href="`/dashboard/semester-courses/${course.id}/edit`">
-                  <Cog6ToothIcon class="w-5" />
+                  <PencilSquareIcon class="w-5" />
                 </Button>
                 <Button class="text-red-600" @click="[showModal = true, courseToDeleteId = course.id]">
                   <XCircleIcon class="w-5" />

--- a/resources/js/Pages/Dashboard/CourseSemester/Show.vue
+++ b/resources/js/Pages/Dashboard/CourseSemester/Show.vue
@@ -12,7 +12,7 @@ import FormError from '@/Shared/Forms/FormError.vue'
 import ManagementHeader from '@/Shared/Components/ManagementHeader.vue'
 import ManagementHeaderItem from '@/Shared/Components/ManagementHeaderItem.vue'
 import RemoveModal from '@/Shared/Modals/RemoveModal.vue'
-import { Cog6ToothIcon, UsersIcon, XCircleIcon, ChartBarIcon } from '@heroicons/vue/24/outline'
+import { PencilSquareIcon, UsersIcon, XCircleIcon, ChartBarIcon } from '@heroicons/vue/24/outline'
 import { ref } from 'vue'
 
 const props = defineProps({
@@ -187,17 +187,21 @@ function updateGroup() {
           >
             {{ group.name }}[{{ group.formAbbreviation }}]
             <div class="flex gap-2">
-              <Button :href="`/dashboard/semester-courses/${course.data.id}/groups/${group.id}/grades`">
+              <Button class="has-tooltip" :href="`/dashboard/semester-courses/${course.data.id}/groups/${group.id}/grades`">
                 <ChartBarIcon class="w-5" />
+                <span class='tooltip p-1 rounded bg-gray-500 text-white -ml-6 -mt-16'>Oceny</span>
               </Button>
-              <Button :href="`/dashboard/semester-courses/${course.data.id}/groups/${group.id}/students`">
+              <Button class="has-tooltip" :href="`/dashboard/semester-courses/${course.data.id}/groups/${group.id}/students`">
                 <UsersIcon class="w-5" />
+                <span class='tooltip p-1 rounded bg-gray-500 text-white -ml-8 -mt-16'>Studenci</span>
               </Button>
-              <Button>
-                <Cog6ToothIcon class="w-5" @click="editGroup(group)" />
+              <Button class="has-tooltip">
+                <PencilSquareIcon class="w-5" @click="editGroup(group)" />
+                <span class='tooltip p-1 rounded bg-gray-500 text-white -ml-10 -mt-16'>Edytuj grupę</span>
               </Button>
-              <Button class="text-red-600" @click="[showModal = true, showEditForm = false, groupToDeleteId = group.id]">
+              <Button class="text-red-600 has-tooltip" @click="[showModal = true, showEditForm = false, groupToDeleteId = group.id]">
                 <XCircleIcon class="w-5" />
+                <span class='tooltip p-1 rounded bg-rose-300 text-white -ml-10 -mt-16'>Usuń grupę</span>
               </Button>
             </div>
           </div>

--- a/resources/js/Pages/Dashboard/CourseSemester/Show.vue
+++ b/resources/js/Pages/Dashboard/CourseSemester/Show.vue
@@ -189,19 +189,19 @@ function updateGroup() {
             <div class="flex gap-2">
               <Button class="has-tooltip" :href="`/dashboard/semester-courses/${course.data.id}/groups/${group.id}/grades`">
                 <ChartBarIcon class="w-5" />
-                <span class='tooltip p-1 rounded bg-gray-500 text-white -ml-6 -mt-16'>Oceny</span>
+                <span class="tooltip -ml-6 -mt-16 rounded bg-gray-500 p-1 text-white">Oceny</span>
               </Button>
               <Button class="has-tooltip" :href="`/dashboard/semester-courses/${course.data.id}/groups/${group.id}/students`">
                 <UsersIcon class="w-5" />
-                <span class='tooltip p-1 rounded bg-gray-500 text-white -ml-8 -mt-16'>Studenci</span>
+                <span class="tooltip -ml-8 -mt-16 rounded bg-gray-500 p-1 text-white">Studenci</span>
               </Button>
               <Button class="has-tooltip">
                 <PencilSquareIcon class="w-5" @click="editGroup(group)" />
-                <span class='tooltip p-1 rounded bg-gray-500 text-white -ml-10 -mt-16'>Edytuj grupę</span>
+                <span class="tooltip -ml-10 -mt-16 rounded bg-gray-500 p-1 text-white">Edytuj grupę</span>
               </Button>
-              <Button class="text-red-600 has-tooltip" @click="[showModal = true, showEditForm = false, groupToDeleteId = group.id]">
+              <Button class="has-tooltip text-red-600" @click="[showModal = true, showEditForm = false, groupToDeleteId = group.id]">
                 <XCircleIcon class="w-5" />
-                <span class='tooltip p-1 rounded bg-rose-300 text-white -ml-10 -mt-16'>Usuń grupę</span>
+                <span class="tooltip -ml-10 -mt-16 rounded bg-rose-300 p-1 text-white">Usuń grupę</span>
               </Button>
             </div>
           </div>

--- a/resources/js/Pages/Dashboard/FAQ/Index.vue
+++ b/resources/js/Pages/Dashboard/FAQ/Index.vue
@@ -10,7 +10,7 @@ import RemoveModal from '@/Shared/Modals/RemoveModal.vue'
 import { ref } from 'vue'
 import ManagementHeader from '@/Shared/Components/ManagementHeader.vue'
 import ManagementHeaderItem from '@/Shared/Components/ManagementHeaderItem.vue'
-import { Cog6ToothIcon, XCircleIcon } from '@heroicons/vue/24/outline'
+import { PencilSquareIcon, XCircleIcon } from '@heroicons/vue/24/outline'
 
 defineProps({
   faqs: Object,
@@ -65,7 +65,7 @@ const faqToDeleteId = ref(0)
               </TableCell>
               <TableCell class="flex justify-end gap-2">
                 <Button :href="`/dashboard/faqs/${faq.id}/edit`">
-                  <Cog6ToothIcon class="w-5" />
+                  <PencilSquareIcon class="w-5" />
                 </Button>
                 <Button class="text-red-600" @click="[showModal = true, faqToDeleteId = faq.id]">
                   <XCircleIcon class="w-5" />

--- a/resources/js/Pages/Dashboard/Field/Index.vue
+++ b/resources/js/Pages/Dashboard/Field/Index.vue
@@ -10,7 +10,7 @@ import RemoveModal from '@/Shared/Modals/RemoveModal.vue'
 import { ref } from 'vue'
 import ManagementHeader from '@/Shared/Components/ManagementHeader.vue'
 import ManagementHeaderItem from '@/Shared/Components/ManagementHeaderItem.vue'
-import { Cog6ToothIcon, XCircleIcon } from '@heroicons/vue/24/outline'
+import { PencilSquareIcon, XCircleIcon } from '@heroicons/vue/24/outline'
 
 defineProps({
   fields: Object,
@@ -71,7 +71,7 @@ const fieldToDeleteId = ref(0)
               </TableCell>
               <TableCell class="flex justify-end gap-2">
                 <Button :href="`/dashboard/fields/${field.id}/edit`">
-                  <Cog6ToothIcon class="w-5" />
+                  <PencilSquareIcon class="w-5" />
                 </Button>
                 <Button class="text-red-600" @click="[showModal = true, fieldToDeleteId = field.id]">
                   <XCircleIcon class="w-5" />

--- a/resources/js/Pages/Dashboard/News/Index.vue
+++ b/resources/js/Pages/Dashboard/News/Index.vue
@@ -13,7 +13,7 @@ import { Inertia } from '@inertiajs/inertia'
 import { debounce } from 'lodash'
 import TextInput from '@/Shared/Forms/TextInput.vue'
 import { useForm } from '@inertiajs/inertia-vue3'
-import { Cog6ToothIcon, XCircleIcon } from '@heroicons/vue/24/outline'
+import { PencilSquareIcon, XCircleIcon } from '@heroicons/vue/24/outline'
 import ManagementHeader from '@/Shared/Components/ManagementHeader.vue'
 import ManagementHeaderItem from '@/Shared/Components/ManagementHeaderItem.vue'
 
@@ -97,7 +97,7 @@ watch(form, debounce(() => {
               </TableCell>
               <TableCell class="flex justify-end gap-2">
                 <Button :href="`news/${article.id}/edit`">
-                  <Cog6ToothIcon class="w-5" />
+                  <PencilSquareIcon class="w-5" />
                 </Button>
                 <Button class="text-red-600" @click="[showModal = true, newsToDeleteId = article.id]">
                   <XCircleIcon class="w-5" />

--- a/resources/js/Pages/Dashboard/Semester/Index.vue
+++ b/resources/js/Pages/Dashboard/Semester/Index.vue
@@ -11,7 +11,7 @@ import { ref } from 'vue'
 import { Method } from '@inertiajs/inertia'
 import ManagementHeader from '@/Shared/Components/ManagementHeader.vue'
 import ManagementHeaderItem from '@/Shared/Components/ManagementHeaderItem.vue'
-import { Cog6ToothIcon, XCircleIcon, CheckIcon } from '@heroicons/vue/24/outline'
+import { PencilSquareIcon, XCircleIcon, CheckIcon } from '@heroicons/vue/24/outline'
 
 defineProps({
   semesters: Object,
@@ -79,7 +79,7 @@ const semesterToDeleteId = ref(0)
                   <CheckIcon class="w-5" />
                 </Button>
                 <Button :href="`/dashboard/semesters/${semester.id}/edit`">
-                  <Cog6ToothIcon class="w-5" />
+                  <PencilSquareIcon class="w-5" />
                 </Button>
                 <Button class="text-red-600" @click="[showModal = true, semesterToDeleteId = semester.id]">
                   <XCircleIcon class="w-5" />

--- a/resources/js/Pages/Dashboard/Student/Index.vue
+++ b/resources/js/Pages/Dashboard/Student/Index.vue
@@ -13,7 +13,7 @@ import { Inertia } from '@inertiajs/inertia'
 import { debounce } from 'lodash'
 import TextInput from '@/Shared/Forms/TextInput.vue'
 import { useForm } from '@inertiajs/inertia-vue3'
-import { Cog6ToothIcon, XCircleIcon } from '@heroicons/vue/24/outline'
+import { PencilSquareIcon, XCircleIcon } from '@heroicons/vue/24/outline'
 import ManagementHeader from '@/Shared/Components/ManagementHeader.vue'
 import ManagementHeaderItem from '@/Shared/Components/ManagementHeaderItem.vue'
 
@@ -97,7 +97,7 @@ watch(form, debounce(() => {
               </TableCell>
               <TableCell class="flex justify-end gap-2">
                 <Button :href="`students/${student.id}/edit`">
-                  <Cog6ToothIcon class="w-5" />
+                  <PencilSquareIcon class="w-5" />
                 </Button>
                 <Button class="text-red-600" @click="[showModal = true, studentToDeleteId = student.id]">
                   <XCircleIcon class="w-5" />


### PR DESCRIPTION
Connected with #103.
Added tooltips with informations about places where buttons directs.

Its needed now in one place(IMO):

[Screencast from 13-08-24 08:31:35.webm](https://github.com/user-attachments/assets/b12eab2d-f923-4cf2-a44a-d42ab909a23d)

but we must think if thats needed on indexes where we have 3 options - edit, show and delete.

Update cog icon into pencil - in edit buttons.