### PR TITLE
#114 - batch students import

### DIFF
--- a/app/Actions/WuStudentsImport.php
+++ b/app/Actions/WuStudentsImport.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Models\Student;
+
+class WuStudentsImport
+{
+    protected array $students = [];
+
+    public function import(string $content): array
+    {
+        $previousLine = null;
+
+        foreach (explode("\n", $content) as $line) {
+            if (str_starts_with($line, "nr albumu:")) {
+                $names = explode(" ", $previousLine);
+
+                $this->students[] = new Student([
+                    "first_name" => $names[1] ?? "",
+                    "surname" => $names[0] ?? "",
+                    "index_number" => str_replace("nr albumu:", "", $line),
+                ]);
+            }
+
+            $previousLine = $line;
+        }
+
+        return $this->students;
+    }
+
+    public function save(): void
+    {
+        /** @var Student $student */
+        foreach ($this->students as $student) {
+            if (Student::query()->where("index_number", $student->index_number)->count() === 0) {
+                $student->save();
+            }
+        }
+    }
+}

--- a/app/Http/Controllers/Dashboard/StudentController.php
+++ b/app/Http/Controllers/Dashboard/StudentController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Dashboard;
 
+use App\Actions\WuStudentsImport;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreStudentRequest;
 use App\Http\Requests\UpdateStudentRequest;
@@ -72,5 +73,20 @@ class StudentController extends Controller
 
         return redirect()->back()
             ->with("success", "Usunięto studenta");
+    }
+
+    public function import(): Response
+    {
+        return inertia("Dashboard/Student/Import");
+    }
+
+    public function storeMany(Request $request, WuStudentsImport $importer): RedirectResponse
+    {
+        $importer->import($request->get("content") ?? "");
+        $importer->save();
+
+        return redirect()
+            ->route("students.index")
+            ->with("success", "Dodano studentów");
     }
 }

--- a/resources/js/Pages/Dashboard/Student/Import.vue
+++ b/resources/js/Pages/Dashboard/Student/Import.vue
@@ -1,0 +1,56 @@
+<script setup>
+import DashboardLayout from '@/Layouts/DashboardLayout.vue'
+import Section from '@/Shared/Components/Section.vue'
+import SubmitButton from '@/Shared/Components/Buttons/SubmitButton.vue'
+import FormGroup from '@/Shared/Forms/FormGroup.vue'
+import FormLabel from '@/Shared/Forms/FormLabel.vue'
+import { useForm } from '@inertiajs/inertia-vue3'
+import FormError from '@/Shared/Forms/FormError.vue'
+import ManagementHeader from '@/Shared/Components/ManagementHeader.vue'
+import ManagementHeaderItem from '@/Shared/Components/ManagementHeaderItem.vue'
+
+const form = useForm({
+  content: '',
+})
+
+function importStudents() {
+  form.post('/dashboard/students/import')
+}
+</script>
+
+<template>
+  <DashboardLayout>
+    <div class="flex flex-col gap-8">
+      <ManagementHeader>
+        <template #header>
+          Zarządzanie studentami (masowo)
+        </template>
+        <template #statistics>
+          <ManagementHeaderItem>
+            Formularz dodawania nowych studentów
+          </ManagementHeaderItem>
+        </template>
+      </ManagementHeader>
+
+      <form class="grid grid-cols-2" @submit.prevent="importStudents">
+        <Section>
+          <div class="flex flex-col justify-between gap-4">
+            <FormGroup>
+              <FormLabel for="content">
+                Źródło strony z WU
+                <span class="text-gray-500">(uczelna -> protokoły -> edytuj)</span>
+              </FormLabel>
+              <textarea v-model="form.content" class="block h-[320px] w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 sm:text-sm sm:leading-6" />
+              <FormError :error="form.errors.content" />
+            </FormGroup>
+            <div class="mt-4 flex justify-end">
+              <SubmitButton>
+                Importuj
+              </SubmitButton>
+            </div>
+          </div>
+        </Section>
+      </form>
+    </div>
+  </DashboardLayout>
+</template>

--- a/resources/js/Pages/Dashboard/Student/Import.vue
+++ b/resources/js/Pages/Dashboard/Student/Import.vue
@@ -38,7 +38,7 @@ function importStudents() {
             <FormGroup>
               <FormLabel for="content">
                 Źródło strony z WU
-                <span class="text-gray-500">(uczelna -> protokoły -> edytuj)</span>
+                <span class="text-gray-500">(uczelnia -> protokoły -> edytuj)</span>
               </FormLabel>
               <textarea v-model="form.content" class="block h-[320px] w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 sm:text-sm sm:leading-6" />
               <FormError :error="form.errors.content" />

--- a/resources/js/Pages/Dashboard/Student/Index.vue
+++ b/resources/js/Pages/Dashboard/Student/Index.vue
@@ -59,6 +59,9 @@ watch(form, debounce(() => {
         </template>
         <template #actions>
           <TextInput v-if="total || form.search.length > 0" id="filter" v-model="form.search" placeholder="Szukaj" type="search" class="max-w-lg" />
+          <Button :href="`/dashboard/students/import`">
+            Dodaj masowo
+          </Button>
           <Button :href="`/dashboard/students/create`">
             Dodaj
           </Button>

--- a/resources/js/Pages/Public/News/Index.vue
+++ b/resources/js/Pages/Public/News/Index.vue
@@ -39,6 +39,7 @@ defineProps({
                     {{ post.title }}
                   </a>
                 </h3>
+                <!-- eslint-disable vue/no-v-html (as is sanitized) -->
                 <p class="mt-5 line-clamp-3 text-sm leading-6 text-gray-600" v-html="sanitizeHtml(post.content)" />
               </div>
             </article>

--- a/resources/js/Pages/Public/News/News.vue
+++ b/resources/js/Pages/Public/News/News.vue
@@ -24,6 +24,7 @@ defineProps({
             </template>
           </SectionHeader>
 
+          <!-- eslint-disable vue/no-v-html (as is sanitized) -->
           <div class="mt-10" v-html="sanitizeHtml(news.content)" />
         </div>
       </div>

--- a/resources/tests/wu/protocol001.txt
+++ b/resources/tests/wu/protocol001.txt
@@ -1,0 +1,438 @@
+
+Collegium Witelona
+Uczelnia Państwowa
+
+    dane nauczyciela
+
+uczelnia
+prace dyplomowe
+ankiety
+wiadomości
+HARMONOGRAMY
+PRK
+
+ENPL
+John Keating
+wyloguj
+
+
+szczegóły protokołu
+
+protokol/2023/0/ABC/0/00
+Protokół: 	protokol/2023/0/ABC/0/00 	rok akademicki:	2023/24l
+kierunek: 	Informatyka 	przedmiot:	Projektowanie i programowanie systemów internetowych I
+wydział: 	Wydział Nauk Technicznych i Ekonomicznych
+forma studiów:	stacjonarne 	typ przedmiotu:	Projekt
+rodzaj studiów:	Studia I stopnia - inżynierskie 	specjalność:	programowanie aplikacji mobilnych i internetowych
+rok studiów:	2 	semestr:	4
+protokoł ważny od:	2024-04-22 	protokoł ważny do:	2024-09-29
+typ zakończenia:	zaliczenie z oceną 	twórca protokołu:	Gale Nolan [-]
+operacje
+pokaż termin 1
+pokaż termin 2
+
+
+
+
+wystawianie ocen
+domyślna data wystawienia oceny:
+tabela wystawiania ocen
+lp. 		student 	termin 1 Ważny od 2024-04-22 do 2024-07-03 	termin 2 Ważny od 2024-09-09 do 2024-09-29
+1
+Term. 1
+Term. 2
+
+Black Sirius
+nr albumu:83507
+podstawowy
+
+dobry plus
+(09-06-2024)
+brak oceny
+2
+Term. 1
+Term. 2
+
+Bones Susan
+nr albumu:83608
+podstawowy
+
+bardzo dobry
+(09-06-2024)
+brak oceny
+3
+Term. 1
+Term. 2
+
+Brown Lavender
+nr albumu:83609
+podstawowy
+
+dobry
+(09-06-2024)
+brak oceny
+4
+Term. 1
+Term. 2
+
+Chang Cho
+nr albumu:83617
+podstawowy
+
+bardzo dobry
+(09-06-2024)
+brak oceny
+5
+Term. 1
+Term. 2
+
+Creevey Colin
+nr albumu:83737
+podstawowy
+
+bardzo dobry
+(09-06-2024)
+brak oceny
+6
+Term. 1
+Term. 2
+
+Delacour Fleur
+nr albumu:83783
+podstawowy
+
+dostateczny plus
+(09-06-2024)
+brak oceny
+7
+Term. 1
+Term. 2
+
+Diggory Cedric
+nr albumu:83810
+podstawowy
+
+dobry
+(09-06-2024)
+brak oceny
+8
+Term. 1
+Term. 2
+
+Dumbledore Albus
+nr albumu:83897
+podstawowy
+
+dobry
+(09-06-2024)
+brak oceny
+9
+Term. 1
+Term. 2
+
+Dursley Dudley
+nr albumu:83933
+podstawowy
+
+dostateczny plus
+(09-06-2024)
+brak oceny
+10
+Term. 1
+Term. 2
+
+Filch Argus
+nr albumu:83947
+podstawowy
+
+dobry plus
+(09-06-2024)
+brak oceny
+11
+Term. 1
+Term. 2
+
+Finnigan Seamus
+nr albumu:83957
+podstawowy
+
+dostateczny plus
+(09-06-2024)
+brak oceny
+12
+Term. 1
+Term. 2
+
+Granger Hermione
+nr albumu:84096
+podstawowy
+
+dobry
+(09-06-2024)
+brak oceny
+13
+Term. 1
+Term. 2
+
+Hagrid Rubeus
+nr albumu:84118
+podstawowy
+
+dobry
+(09-06-2024)
+brak oceny
+14
+Term. 1
+Term. 2
+
+Jordan Lee
+nr albumu:84552
+podstawowy
+
+bardzo dobry
+(09-06-2024)
+brak oceny
+15
+Term. 1
+Term. 2
+
+Krum Viktor
+nr albumu:84636
+podstawowy
+
+dobry plus
+(09-06-2024)
+brak oceny
+16
+Term. 1
+Term. 2
+
+Lestrange Bellatrix
+nr albumu:84709
+podstawowy
+
+dobry
+(09-06-2024)
+brak oceny
+17
+Term. 1
+Term. 2
+
+Lockhart Gilderoy
+nr albumu:84770
+podstawowy
+
+dobry plus
+(09-06-2024)
+brak oceny
+18
+Term. 1
+Term. 2
+
+Longbottom Neville
+nr albumu:84797
+podstawowy
+
+dostateczny plus
+(09-06-2024)
+brak oceny
+19
+Term. 1
+Term. 2
+
+Lovegood Luna
+nr albumu:84853
+podstawowy
+
+dobry
+(09-06-2024)
+brak oceny
+20
+Term. 1
+Term. 2
+
+Lupin Remus
+nr albumu:85128
+podstawowy
+
+dobry
+(09-06-2024)
+brak oceny
+21
+Term. 1
+Term. 2
+
+Macmillan Ernie
+nr albumu:85228
+podstawowy
+
+dobry plus
+(09-06-2024)
+brak oceny
+22
+Term. 1
+Term. 2
+
+Malfoy Draco
+nr albumu:85388
+podstawowy
+
+dobry
+(09-06-2024)
+brak oceny
+23
+Term. 1
+Term. 2
+
+Moody Alastor
+nr albumu:85480
+podstawowy
+
+niedostateczny
+(09-06-2024)
+brak oceny
+24
+Term. 1
+Term. 2
+
+Parkinson Pansy
+nr albumu:85507
+podstawowy
+
+bardzo dobry
+(13-06-2024)
+brak oceny
+25
+Term. 1
+Term. 2
+
+Patil Padma
+nr albumu:85601
+podstawowy
+
+bardzo dobry
+(09-06-2024)
+brak oceny
+26
+Term. 1
+Term. 2
+
+Patil Parvati
+nr albumu:85819
+podstawowy
+
+dostateczny plus
+(09-06-2024)
+brak oceny
+27
+Term. 1
+Term. 2
+
+Pettigrew Peter
+nr albumu:85857
+podstawowy
+
+dostateczny plus
+(09-06-2024)
+brak oceny
+28
+Term. 1
+Term. 2
+
+Potter Harry
+nr albumu:85871
+podstawowy
+
+dobry plus
+(09-06-2024)
+brak oceny
+29
+Term. 1
+Term. 2
+
+Riddle Tom
+nr albumu:85999
+podstawowy
+
+dobry plus
+(09-06-2024)
+brak oceny
+30
+Term. 1
+Term. 2
+
+Scamander Newt
+nr albumu:86115
+podstawowy
+
+dobry plus
+(09-06-2024)
+brak oceny
+31
+Term. 1
+Term. 2
+
+Slughorn Horace
+nr albumu:86122
+podstawowy
+
+dobry plus
+(09-06-2024)
+brak oceny
+32
+Term. 1
+Term. 2
+
+Snape Severus
+nr albumu:86177
+podstawowy
+
+dobry plus
+(09-06-2024)
+brak oceny
+33
+Term. 1
+Term. 2
+
+Trelawney Sybill
+nr albumu:86340
+podstawowy
+
+dobry plus
+(09-06-2024)
+brak oceny
+34
+Term. 1
+Term. 2
+
+Weasley Ginny
+nr albumu:86866
+podstawowy
+
+bardzo dobry
+(09-06-2024)
+brak oceny
+35
+Term. 1
+Term. 2
+
+Weasley Ron
+nr albumu:86980
+podstawowy
+
+bardzo dobry
+(09-06-2024)
+brak oceny
+36
+Term. 1
+Term. 2
+
+Zabini Blais
+nr albumu:87144
+podstawowy
+
+dobry plus
+(09-06-2024)
+brak oceny
+Deklaracja dostępności
+Simple.Bazus © Wszelkie prawa zastrzeżone 2005 - 2024 | wu#2016.1.5263#0#20240812_063613 | wsrest#2016.1.5490#1.7.1143#20240812_063603

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,6 +55,8 @@ Route::middleware("auth")->prefix("dashboard")->group(function (): void {
         Route::get("/students/{student}/edit", "edit")->name("students.edit");
         Route::patch("/students/{student}", "update")->name("students.update");
         Route::delete("/students/{student}", "destroy")->name("students.destroy");
+        Route::get("/students/import", "import")->name("students.import");
+        Route::post("/students/import", "storeMany")->name("students.import.post");
     });
     Route::controller(SemesterController::class)->group(function (): void {
         Route::get("/semesters", "index")->name("semesters.index");

--- a/tests/Feature/StudentImportTest.php
+++ b/tests/Feature/StudentImportTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Actions\WuStudentsImport;
+use App\Models\Student;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StudentImportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testStudentsImport(): void
+    {
+        $content = file_get_contents(resource_path("tests/wu/protocol001.txt"));
+
+        $importer = new WuStudentsImport();
+
+        $students = $importer->import($content);
+        $this->assertCount(36, $students);
+
+        $importer->save();
+        $this->assertDatabaseCount(Student::class, 36);
+    }
+
+    public function testRepeatedStudentsImport(): void
+    {
+        $data = [
+            ["first_name" => "Sirius", "surname" => "Black", "index_number" => "83507"],
+            ["first_name" => "Susan", "surname" => "Bones", "index_number" => "83608"],
+            ["first_name" => "Tom", "surname" => "Riddle", "index_number" => "85999"],
+        ];
+
+        Student::factory()->count(count($data))->sequence(...$data)->create();
+
+        $content = file_get_contents(resource_path("tests/wu/protocol001.txt"));
+
+        $importer = new WuStudentsImport();
+
+        $students = $importer->import($content);
+        $this->assertCount(36, $students);
+
+        $importer->save();
+        $this->assertDatabaseCount(Student::class, 36);
+    }
+
+    public function testNewStudentsImport(): void
+    {
+        $data = [
+            ["first_name" => "McGonagall", "surname" => "McGonagall", "index_number" => "89201"],
+        ];
+
+        Student::factory()->count(count($data))->sequence(...$data)->create();
+
+        $content = file_get_contents(resource_path("tests/wu/protocol001.txt"));
+
+        $importer = new WuStudentsImport();
+
+        $students = $importer->import($content);
+        $this->assertCount(36, $students);
+
+        $importer->save();
+        $this->assertDatabaseCount(Student::class, 37);
+    }
+}

--- a/tests/Feature/StudentTest.php
+++ b/tests/Feature/StudentTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Feature\Frontend;
+namespace Tests\Feature;
 
 use App\Models\Student;
 use App\Models\User;


### PR DESCRIPTION
This PR add a feature to semi-import data from WU. All you need is to go to protocol site, CTRL+A and CTRL+C, paste in textarea and run "import". All students from website will be added to the database (unless they're already created).

Anonymised data is used for automated tests, but of course you can use it for manual testing.

![image](https://github.com/user-attachments/assets/7e60b415-148f-4234-91fa-129ee64032c3)

![image](https://github.com/user-attachments/assets/22da2958-221c-4375-b61f-0e0c90ccb8bf)

This should close #114.
