### PR TITLE
#110 - quill version update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
                 "dompurify": "^3.1.6",
                 "laravel-vite-plugin": "^0.8.1",
                 "lodash": "^4.17.21",
-                "primevue": "^3.53.0",
-                "quill": "1.3.7",
+                "quill": "^2.0.2",
                 "tailwindcss": "^3.4.10",
                 "vue": "^3.4.38",
                 "vue-toastification": "^2.0.0-rc.5"
@@ -63,11 +62,11 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.25.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.3.tgz",
-            "integrity": "sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.4.tgz",
+            "integrity": "sha512-nq+eWrOgdtu3jG5Os4TQP3x3cLA8hR8TvJNjD8vnPa20WGycimcparWnLK4jJhElTK6SDyuJo1weMKO/5LpmLA==",
             "dependencies": {
-                "@babel/types": "^7.25.2"
+                "@babel/types": "^7.25.4"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -77,9 +76,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.25.2",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
-            "integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
+            "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.24.8",
                 "@babel/helper-validator-identifier": "^7.24.7",
@@ -1425,14 +1424,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/clone": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-            "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1520,25 +1511,6 @@
                 }
             }
         },
-        "node_modules/deep-equal": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
-            "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
-            "dependencies": {
-                "is-arguments": "^1.1.1",
-                "is-date-object": "^1.0.5",
-                "is-regex": "^1.1.4",
-                "object-is": "^1.1.5",
-                "object-keys": "^1.1.1",
-                "regexp.prototype.flags": "^1.5.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1561,22 +1533,6 @@
                 "es-define-property": "^1.0.0",
                 "es-errors": "^1.3.0",
                 "gopd": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/define-properties": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-            "dependencies": {
-                "define-data-property": "^1.0.1",
-                "has-property-descriptors": "^1.0.0",
-                "object-keys": "^1.1.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -1638,9 +1594,9 @@
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.11",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.11.tgz",
-            "integrity": "sha512-R1CccCDYqndR25CaXFd6hp/u9RaaMcftMkphmvuepXr5b1vfLkRml6aWVeBhXJ7rbevHkKEMJtz8XqPf7ffmew==",
+            "version": "1.5.13",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
+            "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
             "dev": true
         },
         "node_modules/emoji-regex": {
@@ -1968,14 +1924,9 @@
             }
         },
         "node_modules/eventemitter3": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
-            "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
-        },
-        "node_modules/extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -1984,9 +1935,9 @@
             "dev": true
         },
         "node_modules/fast-diff": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-            "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+            "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="
         },
         "node_modules/fast-glob": {
             "version": "3.3.2",
@@ -2180,14 +2131,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/functions-have-names": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/get-intrinsic": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
@@ -2354,20 +2297,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/has-tostringtag": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "dependencies": {
-                "has-symbols": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/hasown": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -2430,21 +2359,6 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
-        "node_modules/is-arguments": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2457,25 +2371,11 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
-            "integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
+            "version": "2.15.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+            "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
             "dependencies": {
                 "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-date-object": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-            "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-            "dependencies": {
-                "has-tostringtag": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -2526,21 +2426,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/is-regex": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-            "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/isexe": {
@@ -2669,6 +2554,11 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "node_modules/lodash-es": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
         },
         "node_modules/lodash.castarray": {
             "version": "4.4.0",
@@ -2879,29 +2769,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/object-is": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-            "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "define-properties": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/object-keys": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2964,9 +2831,9 @@
             "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw=="
         },
         "node_modules/parchment": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
-            "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
+            "integrity": "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A=="
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
@@ -3235,14 +3102,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/primevue": {
-            "version": "3.53.0",
-            "resolved": "https://registry.npmjs.org/primevue/-/primevue-3.53.0.tgz",
-            "integrity": "sha512-mRqTPGGZX+3AQokaCCjxLVSNEjGEA7LaPdBT4qSpGEdMstK6vhUBCxgLH7IPjHudbaSi4Xo3CIO62pXQxbz8dQ==",
-            "peerDependencies": {
-                "vue": "^3.0.0"
-            }
-        },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3291,29 +3150,30 @@
             ]
         },
         "node_modules/quill": {
-            "version": "1.3.7",
-            "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
-            "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.2.tgz",
+            "integrity": "sha512-QfazNrhMakEdRG57IoYFwffUIr04LWJxbS/ZkidRFXYCQt63c1gK6Z7IHUXMx/Vh25WgPBU42oBaNzQ0K1R/xw==",
             "dependencies": {
-                "clone": "^2.1.1",
-                "deep-equal": "^1.0.1",
-                "eventemitter3": "^2.0.3",
-                "extend": "^3.0.2",
-                "parchment": "^1.1.4",
-                "quill-delta": "^3.6.2"
+                "eventemitter3": "^5.0.1",
+                "lodash-es": "^4.17.21",
+                "parchment": "^3.0.0",
+                "quill-delta": "^5.1.0"
+            },
+            "engines": {
+                "npm": ">=8.2.3"
             }
         },
         "node_modules/quill-delta": {
-            "version": "3.6.3",
-            "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
-            "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+            "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
             "dependencies": {
-                "deep-equal": "^1.0.1",
-                "extend": "^3.0.2",
-                "fast-diff": "1.1.2"
+                "fast-diff": "^1.3.0",
+                "lodash.clonedeep": "^4.5.0",
+                "lodash.isequal": "^4.5.0"
             },
             "engines": {
-                "node": ">=0.10"
+                "node": ">= 12.0.0"
             }
         },
         "node_modules/read-cache": {
@@ -3333,23 +3193,6 @@
             },
             "engines": {
                 "node": ">=8.10.0"
-            }
-        },
-        "node_modules/regexp.prototype.flags": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
-            "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
-            "dependencies": {
-                "call-bind": "^1.0.6",
-                "define-properties": "^1.2.1",
-                "es-errors": "^1.3.0",
-                "set-function-name": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/resolve": {
@@ -3461,20 +3304,6 @@
                 "function-bind": "^1.1.2",
                 "get-intrinsic": "^1.2.4",
                 "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/set-function-name": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-            "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-            "dependencies": {
-                "define-data-property": "^1.1.4",
-                "es-errors": "^1.3.0",
-                "functions-have-names": "^1.2.3",
                 "has-property-descriptors": "^1.0.2"
             },
             "engines": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
         "dompurify": "^3.1.6",
         "laravel-vite-plugin": "^0.8.1",
         "lodash": "^4.17.21",
-        "primevue": "^3.53.0",
-        "quill": "1.3.7",
+        "quill": "^2.0.2",
         "tailwindcss": "^3.4.10",
         "vue": "^3.4.38",
         "vue-toastification": "^2.0.0-rc.5"

--- a/resources/js/Pages/Dashboard/CourseSemester/Index.vue
+++ b/resources/js/Pages/Dashboard/CourseSemester/Index.vue
@@ -45,7 +45,7 @@ const courseToDeleteId = ref(0)
           </span>
         </template>
       </ManagementHeader>
-      <div v-if="courses.data.length" class="flex flex-col gap-8">
+      <div v-if="courses.length" class="flex flex-col gap-8">
         <TableWrapper>
           <template #header>
             <TableHeader class="w-1/6">
@@ -63,7 +63,7 @@ const courseToDeleteId = ref(0)
             <TableHeader />
           </template>
           <template #body>
-            <TableRow v-for="course in courses.data" :key="course.id">
+            <TableRow v-for="course in courses" :key="course.id">
               <TableCell class="pr-12 opacity-75">
                 {{ course.id }}
               </TableCell>

--- a/resources/js/Shared/Forms/TextAreaEditor.vue
+++ b/resources/js/Shared/Forms/TextAreaEditor.vue
@@ -1,51 +1,69 @@
-<script setup>
-import { computed } from 'vue'
-import Editor from 'primevue/editor'
+<script>
+import Quill from 'quill'
+import 'quill/dist/quill.snow.css'
 
-const modules = {
-  keyboard: {
-    bindings: {
-      tab: false,
+export default {
+  name: 'QuillEditor',
+  props: {
+    modelValue: {
+      type: String,
+      default: '',
+    },
+    editorStyle: {
+      type: Object,
+      default: () => ({ height: '320px' }),
     },
   },
-}
+  emits: ['update:modelValue'],
+  watch: {
+    modelValue(newValue) {
+      if (newValue !== this.quill.root.innerHTML) {
+        this.quill.root.innerHTML = newValue
+      }
+    },
+  },
+  mounted() {
+    this.quill = new Quill(this.$refs.editorContainer, {
+      theme: 'snow',
+      modules: {
+        toolbar: this.$refs.editorToolbar,
+      },
+    })
 
-const props = defineProps({
-  modelValue: {
-    type: [String, Number],
-    default: null,
+    this.quill.on('text-change', () => {
+      const content = this.quill.root.innerHTML
+      this.$emit('update:modelValue', content)
+    })
+
+    this.quill.root.innerHTML = this.modelValue
   },
-  error: {
-    type: String,
-    default: null,
-  },
-})
-const emit = defineEmits(['update:modelValue'])
-const value = computed({
-  get: () => props.modelValue,
-  set: (value) => {
-    emit('update:modelValue', value)
-  },
-})
+}
 </script>
 
 <template>
-  <Editor v-model="value" :modules="modules" editor-style="height: 320px" class="focus-within:border-brand-black hover:border-brand-black border border-transparent">
-    <template #toolbar>
-      <!-- eslint-disable tailwindcss/no-custom-classname -->
+  <div>
+    <div ref="editorToolbar" class="ql-toolbar">
       <span class="ql-formats">
-        <button class="ql-header" aria-label="Heading H1" value="1" />
-        <button class="ql-header" aria-label="Heading H2" value="2" />
-        <button class="ql-bold" aria-label="Bold" />
-        <button class="ql-italic" aria-label="Italic" />
-        <button class="ql-underline" aria-label="Underline" />
-        <button class="ql-strike" aria-label="Strike" />
-        <button class="ql-code-block" aria-label="Code" />
-        <button class="ql-list" value="ordered" aria-label="Ordered list" />
-        <button class="ql-list" value="bullet" aria-label="Unordered list" />
-        <button class="ql-link" aria-label="Link" />
+        <button aria-label="Heading H1" class="ql-header" value="1" />
+        <button aria-label="Heading H2" class="ql-header" value="2" />
+        <button aria-label="Bold" class="ql-bold" />
+        <button aria-label="Italic" class="ql-italic" />
+        <button aria-label="Underline" class="ql-underline" />
+        <button aria-label="Strike" class="ql-strike" />
+        <button aria-label="Code" class="ql-code-block" />
+        <button aria-label="Ordered list" class="ql-list" value="ordered" />
+        <button aria-label="Unordered list" class="ql-list" value="bullet" />
+        <button aria-label="Link" class="ql-link" />
       </span>
-      <!-- eslint-enable -->
-    </template>
-  </Editor>
+    </div>
+    <div ref="editorContainer" class="ql-editor" :style="editorStyle" />
+  </div>
 </template>
+
+<style scoped>
+.ql-editor {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 10px;
+}
+</style>


### PR DESCRIPTION
Connected with #110.

Updated `quill` to version 2 and removed not necessary `primevue` package.
Additionally fixed one index.