### PR TITLE
#145 - production seeder

### DIFF
--- a/app/Console/Commands/FlushCache.php
+++ b/app/Console/Commands/FlushCache.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Keating\Console\Commands;
 
-use Illuminate\Cache\CacheManager;
 use Illuminate\Console\Command;
 
 class FlushCache extends Command
@@ -12,7 +11,7 @@ class FlushCache extends Command
     protected $signature = "cache:flush";
     protected $description = "Flush cached data";
 
-    public function handle(CacheManager $cache): void
+    public function handle(): void
     {
         $this->call(FlushCachedPageTitle::class);
         $this->call(FlushCachedScheduleLink::class);

--- a/app/Console/Commands/FlushCache.php
+++ b/app/Console/Commands/FlushCache.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keating\Console\Commands;
+
+use Illuminate\Cache\CacheManager;
+use Illuminate\Console\Command;
+
+class FlushCache extends Command
+{
+    protected $signature = "cache:flush";
+    protected $description = "Flush cached data";
+
+    public function handle(CacheManager $cache): void
+    {
+        $this->call(FlushCachedPageTitle::class);
+        $this->call(FlushCachedScheduleLink::class);
+    }
+}

--- a/app/Console/Commands/FlushCachedScheduleLink.php
+++ b/app/Console/Commands/FlushCachedScheduleLink.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keating\Console\Commands;
+
+use Illuminate\Cache\CacheManager;
+use Illuminate\Console\Command;
+
+class FlushCachedScheduleLink extends Command
+{
+    protected $signature = "cache:link:flush";
+    protected $description = "Flush cached schedule link";
+
+    public function handle(CacheManager $cache): void
+    {
+        $cache->forget("scheduleLink");
+    }
+}

--- a/database/seeders/ProductionSeeder.php
+++ b/database/seeders/ProductionSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Keating\Models\Section;
+use Keating\Models\SectionSettings;
+use Keating\Models\Setting;
+use Keating\Models\User;
+
+class ProductionSeeder extends Seeder
+{
+    public function run(): void
+    {
+        User::factory()->create(["email" => "admin@example.com"]);
+
+        Setting::factory()->create();
+        SectionSettings::query()->create([
+            "banner_enabled" => true,
+            "about_enabled" => true,
+            "counters_enabled" => true,
+            "contact_enabled" => true,
+        ]);
+    }
+}

--- a/database/seeders/ProductionSeeder.php
+++ b/database/seeders/ProductionSeeder.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
-use Keating\Models\Section;
 use Keating\Models\SectionSettings;
 use Keating\Models\Setting;
 use Keating\Models\User;


### PR DESCRIPTION
This should be merged before #154.

This PR adds:
* `ProductionSeeder` to run for application installation: `php artisan db:seed --class=ProductionSeeder`
* command `php artisan cache:flush` to flush cached page title and external schedule link