### PR TITLE
- students multisearch

### DIFF
--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keating\Models;
 
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -20,6 +21,9 @@ use Keating\Enums\StudyForm;
  * @property StudyForm $form
  * @property Carbon $created_at
  * @property Carbon $updated_at
+ * @property-read CourseSemester $course
+ * @property-read Collection<Student> $students
+ * @property-read Collection<GradeColumn> $gradeColumns
  */
 class Group extends Model
 {

--- a/resources/js/Pages/Dashboard/CourseSemester/Student/Index.vue
+++ b/resources/js/Pages/Dashboard/CourseSemester/Student/Index.vue
@@ -75,9 +75,9 @@ watch(form, debounce(() => {
         </template>
       </ManagementHeader>
       <div v-if="studentsFormOpen" class="border-2 border-dotted p-4 sm:rounded-lg">
-        <div class="flex items gap-4">
+        <div class="items flex gap-4">
           <TextInput id="search" v-model="form.search" placeholder="Szukaj studentów do dodania" type="search" class="mb-5 max-w-lg" />
-          <span class="mt-2 text-gray-500 text-sm">podaj imiona, nazwiska, numery indeksu lub zestawy numerów indeksów oddzielone spacjami</span>
+          <span class="mt-2 text-sm text-gray-500">podaj imiona, nazwiska, numery indeksu lub zestawy numerów indeksów oddzielone spacjami</span>
         </div>
         <div v-if="availableStudents.length" class="grid max-h-64 grid-cols-3 gap-4 overflow-y-auto">
           <div v-for="student in availableStudents" :key="student.id" class="flex h-max cursor-pointer items-center justify-between overflow-x-auto bg-white p-4 text-left sm:rounded-lg">
@@ -112,7 +112,7 @@ watch(form, debounce(() => {
           </template>
           <template #body>
             <TableRow v-for="student in students.data" :key="student.id">
-              <TableCell class="pr-12 text-nowrap opacity-75">
+              <TableCell class="text-nowrap pr-12 opacity-75">
                 {{ student.id }}
               </TableCell>
               <TableCell class="">

--- a/resources/js/Pages/Dashboard/CourseSemester/Student/Index.vue
+++ b/resources/js/Pages/Dashboard/CourseSemester/Student/Index.vue
@@ -75,7 +75,10 @@ watch(form, debounce(() => {
         </template>
       </ManagementHeader>
       <div v-if="studentsFormOpen" class="border-2 border-dotted p-4 sm:rounded-lg">
-        <TextInput id="search" v-model="form.search" placeholder="Szukaj studentów do dodania" type="search" class="mb-5 max-w-lg" />
+        <div class="flex items gap-4">
+          <TextInput id="search" v-model="form.search" placeholder="Szukaj studentów do dodania" type="search" class="mb-5 max-w-lg" />
+          <span class="mt-2 text-gray-500 text-sm">podaj imiona, nazwiska, numery indeksu lub zestawy numerów indeksów oddzielone spacjami</span>
+        </div>
         <div v-if="availableStudents.length" class="grid max-h-64 grid-cols-3 gap-4 overflow-y-auto">
           <div v-for="student in availableStudents" :key="student.id" class="flex h-max cursor-pointer items-center justify-between overflow-x-auto bg-white p-4 text-left sm:rounded-lg">
             <div>
@@ -93,10 +96,10 @@ watch(form, debounce(() => {
       <div v-if="students.data.length" class="flex flex-col gap-8">
         <TableWrapper>
           <template #header>
-            <TableHeader class="w-1/6">
+            <TableHeader class="w-1 text-nowrap">
               ID
             </TableHeader>
-            <TableHeader class="w-1/6">
+            <TableHeader class="w-1 text-nowrap">
               Numer indeksu
             </TableHeader>
             <TableHeader class="w-1/5">
@@ -109,10 +112,10 @@ watch(form, debounce(() => {
           </template>
           <template #body>
             <TableRow v-for="student in students.data" :key="student.id">
-              <TableCell class="pr-12 opacity-75">
+              <TableCell class="pr-12 text-nowrap opacity-75">
                 {{ student.id }}
               </TableCell>
-              <TableCell>
+              <TableCell class="">
                 {{ student.index_number }}
               </TableCell>
               <TableCell>

--- a/resources/js/Pages/Dashboard/Student/Index.vue
+++ b/resources/js/Pages/Dashboard/Student/Index.vue
@@ -86,7 +86,7 @@ watch(form, debounce(() => {
           </template>
           <template #body>
             <TableRow v-for="student in students.data" :key="student.id">
-              <TableCell class="pr-12 text-nowrap opacity-75">
+              <TableCell class="text-nowrap pr-12 opacity-75">
                 {{ student.id }}
               </TableCell>
               <TableCell>

--- a/resources/js/Pages/Dashboard/Student/Index.vue
+++ b/resources/js/Pages/Dashboard/Student/Index.vue
@@ -70,10 +70,10 @@ watch(form, debounce(() => {
       <div v-if="students.data.length" class="flex flex-col gap-8">
         <TableWrapper>
           <template #header>
-            <TableHeader class="w-1/6">
+            <TableHeader class="w-1 text-nowrap">
               ID
             </TableHeader>
-            <TableHeader class="w-1/6">
+            <TableHeader class="w-1 text-nowrap">
               Numer indeksu
             </TableHeader>
             <TableHeader class="w-1/5">
@@ -86,7 +86,7 @@ watch(form, debounce(() => {
           </template>
           <template #body>
             <TableRow v-for="student in students.data" :key="student.id">
-              <TableCell class="pr-12 opacity-75">
+              <TableCell class="pr-12 text-nowrap opacity-75">
                 {{ student.id }}
               </TableCell>
               <TableCell>


### PR DESCRIPTION
With this PR, search box for group's students will be acting a little different.

Current behaviour:
* when text is typed into input, results box shows students with names and index numbers filtered by text

New feature:
* if anyone'd pass only numers to the input, results box will show students for all typed index numbers (separated by space)

![multisearch](https://github.com/user-attachments/assets/e22e7fcd-fad2-43b2-abe1-692d6b7fe2c0)

This should make adding students to the group much easier.


